### PR TITLE
typo, resorting

### DIFF
--- a/data_sb/comet_type.shtml
+++ b/data_sb/comet_type.shtml
@@ -738,6 +738,24 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmip-3-prl1-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 1 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL1-V3.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-prl2-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 2 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL2-V3.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-prl3-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 3 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL3-V3.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-PRL-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Prelanding 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-PRL-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC4-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 4 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC4-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
+
 <li><a href="/holdings/ro-d-midas-3-prl-samples-v3.0/dataset.shtml">Rosetta-Orbiter MIDAS 67P Prelanding Samples Calibrated Data v3.0</a></li><!-- RO-D-MIDAS-3-PRL-SAMPLES-V3.0 -->
 <li><a href="/holdings/ro-e-rpcica-2-ear1-raw-v3.0/dataset.html">Rosetta-Orbiter RPCICA Earth Swing-by 1 Raw Data v3.0</a></li><!-- RO-E-RPCICA-2-EAR1-RAW-V3.0 -->
 <li><a href="/holdings/ro-e-rpcica-2-ear2-raw-v3.0/dataset.html">Rosetta-Orbiter RPCICA Earth Swing-by 2 Raw Data v3.0</a></li><!-- RO-E-RPCICA-2-EAR2-RAW-V3.0 -->
@@ -938,22 +956,7 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-x-srem-5-prl-mtp009-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding MTP009 Derived Data</a></li><!-- RO-X-SREM-5-PRL-MTP009-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-rvm1-v1.0/dataset.html">Rosetta-Orbiter SREM Rendezvous Maneuver 1 Derived Data</a></li><!-- RO-X-SREM-5-RVM1-V1.0 -->
 
-<li><a href="/holdings/ro-c-rpcmip-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-PRL-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Prelanding 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-PRL-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC4-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 4 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC4-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
+
 
 <li><a href="/holdings/sakig-c-imf-3-rdr-halley-v1.0/dataset.shtml">Sakigake Interplanetary Magnetic Field Experiment Data</a></li>
 <li><a href="/holdings/sakig-c-sow-3-rdr-halley-v1.0/dataset.shtml">Sakigake Solar Wind Instrument Data</a></li>

--- a/data_sb/missions/rosetta/index.shtml
+++ b/data_sb/missions/rosetta/index.shtml
@@ -906,6 +906,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmip-3-prl1-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 1 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL1-V3.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-prl2-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 2 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL2-V3.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-prl3-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 3 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL3-V3.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-PRL-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Prelanding 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-PRL-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-prl-com-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding Commissioning Raw Data</a></li><!-- RO-X-SREM-2-PRL-COM-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-prl-com-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding Commissioning Derived Data</a></li><!-- RO-X-SREM-5-PRL-COM-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-prl-mtp003-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding MTP003 Raw Data</a></li><!-- RO-X-SREM-2-PRL-MTP003-V1.0 -->
@@ -937,8 +941,7 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-prl-mtp008-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Prelanding MTP008 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-PRL-MTP008-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-prl-mtp009-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Prelanding MTP009 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-PRL-MTP009-V2.0 -->
 
-<li><a href="/holdings/ro-c-rpcmip-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-PRL-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Prelanding 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-PRL-V1.0 -->
+
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#PRL">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1097,6 +1100,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-esc1-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 1 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-ESC1-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-esc1-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 1 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-ESC1-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-esc1-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-ESC1-V3.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC1-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-esc1-mtp010-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 1 MTP010 Raw Data</a></li><!-- RO-X-SREM-2-ESC1-MTP010-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-esc1-mtp010-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 1 MTP010 Derived Data</a></li><!-- RO-X-SREM-5-ESC1-MTP010-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-esc1-mtp011-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 1 MTP011 Raw Data</a></li><!-- RO-X-SREM-2-ESC1-MTP011-V1.0 -->
@@ -1113,8 +1120,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-esc1-mtp012-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 1 MTP012 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC1-MTP012-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-esc1-mtp013-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 1 MTP013 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-ESC1-MTP013-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-esc1-mtp013-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 1 MTP013 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC1-MTP013-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC1-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#ESC1">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1161,6 +1166,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-esc2-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 2 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-ESC2-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-esc2-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 2 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-ESC2-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-esc2-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-ESC2-V3.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC2-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-esc2-mtp014-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 2 MTP014 Raw Data</a></li><!-- RO-X-SREM-2-ESC2-MTP014-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-esc2-mtp014-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 2 MTP014 Derived Data</a></li><!-- RO-X-SREM-5-ESC2-MTP014-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-esc2-mtp015-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 2 MTP015 Raw Data</a></li><!-- RO-X-SREM-2-ESC2-MTP015-V1.0 -->
@@ -1177,8 +1186,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-esc2-mtp016-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 2 MTP016 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC2-MTP016-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-esc2-mtp017-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 2 MTP017 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-ESC2-MTP017-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-esc2-mtp017-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 2 MTP017 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC2-MTP017-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC2-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#ESC2">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1225,6 +1232,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-esc3-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 3 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-ESC3-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-esc3-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 3 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-ESC3-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-esc3-v2.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Calibrated Data v2.0</a></li><!-- RO-C-RPCMIP-3-ESC3-V2.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC3-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-esc3-mtp018-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 3 MTP018 Raw Data</a></li><!-- RO-X-SREM-2-ESC3-MTP018-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-esc3-mtp018-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 3 MTP018 Derived Data</a></li><!-- RO-X-SREM-5-ESC3-MTP018-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-esc3-mtp019-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 3 MTP019 Raw Data</a></li><!-- RO-X-SREM-2-ESC3-MTP019-V1.0 -->
@@ -1241,8 +1252,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-esc3-mtp020-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 3 MTP020 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC3-MTP020-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-esc3-mtp021-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 3 MTP021 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-ESC3-MTP021-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-esc3-mtp021-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 3 MTP021 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC3-MTP021-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC3-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#ESC3">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1288,6 +1297,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-esc4-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 4 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-ESC4-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-esc4-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Escort 4 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-ESC4-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-esc4-v2.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Calibrated Data v2.0</a></li><!-- RO-C-RPCMIP-3-ESC4-V2.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC4-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 4 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC4-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-esc4-mtp022-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 4 MTP022 Raw Data</a></li><!-- RO-X-SREM-2-ESC4-MTP022-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-esc4-mtp022-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 4 MTP022 Derived Data</a></li><!-- RO-X-SREM-5-ESC4-MTP022-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-esc4-mtp023-v1.0/dataset.html">Rosetta-Orbiter SREM Escort 4 MTP023 Raw Data</a></li><!-- RO-X-SREM-2-ESC4-MTP023-V1.0 -->
@@ -1300,8 +1313,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-esc4-mtp023-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 4 MTP023 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC4-MTP023-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-esc4-mtp024-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 4 MTP024 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-ESC4-MTP024-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-esc4-mtp024-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Escort 4 MTP024 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-ESC4-MTP024-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC4-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 4 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC4-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#ESC4">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1346,6 +1357,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-ext1-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Extension 1 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-EXT1-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-ext1-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Extension 1 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-EXT1-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-ext1-v2.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Calibrated Data v2.0</a></li><!-- RO-C-RPCMIP-3-EXT1-V2.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT1-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-ext1-mtp025-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 1 MTP025 Raw Data</a></li><!-- RO-X-SREM-2-EXT1-MTP025-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-ext1-mtp025-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 1 MTP025 Derived Data</a></li><!-- RO-X-SREM-5-EXT1-MTP025-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-ext1-mtp026-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 1 MTP026 Raw Data</a></li><!-- RO-X-SREM-2-EXT1-MTP026-V1.0 -->
@@ -1358,8 +1373,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-ext1-mtp026-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 1 MTP026 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT1-MTP026-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-ext1-mtp027-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 1 MTP027 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-EXT1-MTP027-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-ext1-mtp027-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 1 MTP027 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT1-MTP027-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT1-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#EXT1">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1404,6 +1417,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-ext2-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Extension 2 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-EXT2-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-ext2-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Extension 2 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-EXT2-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-ext2-v2.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Calibrated Data v2.0</a></li><!-- RO-C-RPCMIP-3-EXT2-V2.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-ext2-mtp028-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 2 MTP028 Raw Data</a></li><!-- RO-X-SREM-2-EXT2-MTP028-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-ext2-mtp028-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 2 MTP028 Derived Data</a></li><!-- RO-X-SREM-5-EXT2-MTP028-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-ext2-mtp029-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 2 MTP029 Raw Data</a></li><!-- RO-X-SREM-2-EXT2-MTP029-V1.0 -->
@@ -1416,8 +1433,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-ext2-mtp029-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 2 MTP029 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT2-MTP029-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-ext2-mtp030-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 2 MTP030 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-EXT2-MTP030-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-ext2-mtp030-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 2 MTP030 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT2-MTP030-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#EXT2">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
@@ -1466,6 +1481,10 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmag-3-ext3-calibrated-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Extension 3 67P Calibrated Data v9.0</a></li><!-- RO-C-RPCMAG-3-EXT3-CALIBRATED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmag-4-ext3-resampled-v9.0/dataset.html">Rosetta-Orbiter RPCMAG Extension 3 67P Resampled Data v9.0</a></li><!-- RO-C-RPCMAG-4-EXT3-RESAMPLED-V9.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-ext3-v2.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Calibrated Data v2.0</a></li><!-- RO-C-RPCMIP-3-EXT3-V2.0 -->
+
+<li><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
+
 <li><a href="/holdings/ro-x-srem-2-ext3-mtp031-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 3 MTP031 Raw Data</a></li><!-- RO-X-SREM-2-EXT3-MTP031-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-ext3-mtp031-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 3 MTP031 Derived Data</a></li><!-- RO-X-SREM-5-EXT3-MTP031-V1.0 -->
 <li><a href="/holdings/ro-x-srem-2-ext3-mtp032-v1.0/dataset.html">Rosetta-Orbiter SREM Extension 3 MTP032 Raw Data</a></li><!-- RO-X-SREM-2-EXT3-MTP032-V1.0 -->
@@ -1486,8 +1505,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-ext3-mtp034-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 3 MTP034 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT3-MTP034-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-ext3-mtp035-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 3 MTP035 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-EXT3-MTP035-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-ext3-mtp035-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 3 MTP035 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT3-MTP035-V2.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml#EXT3">Rosetta OSIRIS</a> for a listing of OSIRIS 67P datasets from the comet encounter phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>

--- a/data_sb/target_comets.shtml
+++ b/data_sb/target_comets.shtml
@@ -980,6 +980,23 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-rpcmip-3-prl2-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 2 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL2-V3.0 -->
 <li><a href="/holdings/ro-c-rpcmip-3-prl3-v3.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 3 67P Calibrated Data v3.0</a></li><!-- RO-C-RPCMIP-3-PRL3-V3.0 -->
 
+<li><a href="/holdings/ro-c-rpcmip-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-PRL-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Prelanding 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-PRL-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC4-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 4 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC4-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT1-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
+<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
+
 <li><a href="/holdings/ro-c-virtis-2-prl-com-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Prelanding Commissioning 67P Raw Data</a></li><!-- RO-C-VIRTIS-2-PRL-COM-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-prl-mtp004-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Prelanding MTP004 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-PRL-MTP004-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-2-prl-mtp005-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Prelanding MTP005 67P Raw Data v2.0</a></li><!-- RO-C-VIRTIS-2-PRL-MTP005-V2.0 -->
@@ -1128,23 +1145,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-x-srem-5-prl-mtp007-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding MTP007 Derived Data</a></li><!-- RO-X-SREM-5-PRL-MTP007-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-prl-mtp008-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding MTP008 Derived Data</a></li><!-- RO-X-SREM-5-PRL-MTP008-V1.0 -->
 <li><a href="/holdings/ro-x-srem-5-prl-mtp009-v1.0/dataset.html">Rosetta-Orbiter SREM Prelanding MTP009 Derived Data</a></li><!-- RO-X-SREM-5-PRL-MTP009-V1.0 -->
-
-<li><a href="/holdings/ro-c-rpcmip-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Prelanding 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-PRL-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-prl-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Prelanding 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-PRL-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Escort 4 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-ESC4-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-esc4-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Escort 4 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-ESC4-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 1 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext1-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 1 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT1-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a></li><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
-<li><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a></li><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
 
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_OSIRIS.shtml">Rosetta OSIRIS</a> for a listing of OSIRIS datasets from the <strong><em>comet encounter</em></strong> phases.</em></li>
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>

--- a/index.shtml
+++ b/index.shtml
@@ -82,7 +82,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <br /><a href="/holdings/ro-c-rpcmip-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 2 67P Derived Data</a><!-- RO-C-RPCMIP-5-EXT2-V1.0 -->
 <br /><a href="/holdings/ro-c-rpcmip_rpclap-5-ext2-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 2 67P Cross-Calibrated Derived Data</a><!-- RO-C-RPCMIP/RPCLAP-5-EXT2-V1.0 -->
 <br /><a href="/holdings/ro-c-rpcmip-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP Extension 3 67P Derived Data</a><!-- RO-C-RPCMIP-5-EXT3-V1.0 -->
-v<a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
+<br /><a href="/holdings/ro-c-rpcmip_rpclap-5-ext3-v1.0/dataset.shtml">Rosetta-Orbiter RPCMIP/RPCLAP Extension 3 67P Cross-Calibrated Derived Data</a><!-- RO-C-RPCMIP/RPCLAP-5-EXT3-V1.0 -->
 <br />&nbsp;</li>
 
 <!-- 2023.01.26 -->


### PR DESCRIPTION
fixed typo on home page
moved released datasets from end of sections up so that they are just after other RPCMIP data...