### PR TITLE
comet cross-id changes

### DIFF
--- a/css-n-includes/incl_top.inc
+++ b/css-n-includes/incl_top.inc
@@ -115,7 +115,7 @@ a:active {} /* requires a blank style for :active to stop it being buggy */
 	<li><a href="http://sbib.psi.edu/"><span class="item">Small Bodies Image Browser</span></a></li>
 
 	<!-- <li><a href="/tools/form_sbxid.shtml"><span class="item">Small Bodies Cross-ID Utility</span></a></li> -->
-	<li><a href="/tools/form_cxid.shtml"><span class="item">Comet Cross-ID Utility</span></a></li>
+	<!-- <li><a href="/tools/form_cxid.shtml"><span class="item">Comet Cross-ID Utility</span></a></li> -->
 	<li><a href="/tools/software.shtml#analysis"><span class="item">Small Bodies Modeling</span></a></li>
 	<li><a href="https://naif.jpl.nasa.gov/naif/self_training.html" onclick="this.target='_blank'" class="external"><span class="item">SPICE Self Training</span></a></li>
 	</ul>

--- a/tools/form_cxid.shtml
+++ b/tools/form_cxid.shtml
@@ -21,18 +21,30 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <a name="mainContent"></a>
 <!-- ************************************************** You may begin editing! ************************************************** -->
 <h1>Comet Cross-Identification</h1>
-<p>The majority of the information in this cross-index was compiled from electronic editions of the <em>Catalog of Cometary Orbits</em>, produced by Brian G. Marsden and Gareth V. Williams of the Minor Planet Center (MPC).It is updated regularly as new information becomes available.
+
+<h2>13 Mar 2024: This tool is no longer be maintained.</h2>
+
+<p>Alternative name resolvers:</p>
+
+<ul>
+<li><a href="https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/">Small-Body Database Lookup</a></li>
+<li><a href="https://vo.imcce.fr/webservices/ssodnet/?forms=resolver">The Solar System Open Database Network</a>
+<br />more about the <a href="https://vo.imcce.fr/webservices/ssodnet/?quaero">Quaero</a> API</li>
+</ul>
+
+<!-- <p>The majority of the information in this cross-index was compiled from electronic editions of the <em>Catalog of Cometary Orbits</em>, produced by Brian G. Marsden and Gareth V. Williams of the Minor Planet Center (MPC).It is updated regularly as new information becomes available.
 <br /><br />The Central Bureau for Astronomical Telegrams and the MPC, the organizations responsible for assigning new designations, also maintain a <a href="http://www.minorplanetcenter.net/iau/lists/CometLists.html" onclick="this.target='_blank'">cross-reference utility for comet designations</a>.</p>
 
 <p>Enter a comet name or designation (<a href="/data_sb/resources/designation_formats.shtml#comet_format">Comet Designation Formats</a>).The name or designation will be matched against a cross-index of comets. All apparitions are listed when a name or periodic comet number is given. Additional apparitions are also returned when the given designation refers to a periodic comet.
 <br />Spaces are not significant; case is significant in designations, but not proper names.
-<br />In the resulting display, <strong>Perihelion Date</strong> (on the far right) indicates the time of perihelion passage for that particular apparition. Periodic comets will be listed once for each recorded apparition. The list returned is sorted in order of ascending <strong>Perihelion Date</strong>.</p>
-<form action="/SBNcgi/cxid" method="POST">
+<br />In the resulting display, <strong>Perihelion Date</strong> (on the far right) indicates the time of perihelion passage for that particular apparition. Periodic comets will be listed once for each recorded apparition. The list returned is sorted in order of ascending <strong>Perihelion Date</strong>.</p> -->
+
+<!-- <form action="/SBNcgi/cxid" method="POST">
 
 <h3><label for="comet">Comet Name:</label>
 <input type="text" name="comet" id="comet" placeholder="comet name or designation" size="50" /></h3>
 </form>
-<p>What are the <a href="/data_sb/resources/designation_formats.shtml#comet_format">Comet Designation Formats</a>?</p>
+<p>What are the <a href="/data_sb/resources/designation_formats.shtml#comet_format">Comet Designation Formats</a>?</p> -->
 
 <!-- ************************************************** End editing! ************************************************** -->
 <!--#include virtual="/css-n-includes/incl_bottom.inc"-->


### PR DESCRIPTION
per discussion in 3/13 SBN meeting, remove link from nav but keep page with note that no longer being maintained and links to alternates provided by AR and GB.