### PR TITLE
notification that shape model is lien resolved

### DIFF
--- a/index.shtml
+++ b/index.shtml
@@ -58,6 +58,19 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <h2>New @ SBN</h2>
 <ul class="news">
 
+
+<!-- 2024.05.15 -->
+<li><span class="date">2024.05.15</span>
+<br>+ <a href="/holdings/pds4-dart_shapemodel-v1.0/SUPPORT/dataset.shtml">DART Shapemodel Archive Bundle</a> <code>urn:nasa:pds:dart_shapemodel::1.0</code> has been lien resolved and locally archived. It includes the following collections:
+<ul>
+<li><a href="/holdings/pds4-dart_shapemodel:data_derived_didymos_model_v003-v1.0/SUPPORT/dataset.shtml">Derived data products for DART shapemodel: didymos_model_v003</a> <code>urn:nasa:pds:dart_shapemodel:data_derived_didymos_model_v003::1.0</code></li>
+<li><a href="/holdings/pds4-dart_shapemodel:data_derived_dimorphos_model_v003-v1.0/SUPPORT/dataset.shtml">Derived data products for DART shapemodel: dimorphos_model_v003</a> <code>urn:nasa:pds:dart_shapemodel:data_derived_dimorphos_model_v003::1.0</code></li>
+<li><a href="/holdings/pds4-dart_shapemodel:data_derived_dimorphos_model_v004-v1.0/SUPPORT/dataset.shtml">Derived data products for DART shapemodel: dimorphos_model_v004</a> <code>urn:nasa:pds:dart_shapemodel:data_derived_dimorphos_model_v004::1.0</code></li>
+<li><a href="/holdings/pds4-dart_shapemodel:document-v1.0/SUPPORT/dataset.shtml">Documentation Collection for the DART Shapemodel Archive Bundle</a> <code>urn:nasa:pds:dart_shapemodel:document::1.0</code></li>
+</ul>
+</li>
+
+
 <!-- 2024.01.30 -->
 <li><span class="date">2024.01.30</span> The following New Horizons KEM2 data sets have been released:
 <br>+ <a href="/holdings/nh-a-leisa-2-kem2-v1.0/dataset.shtml">New Horizons LEISA KEM2 Raw Data</a><!-- NH-A-LEISA-2-KEM2-V1.0 -->


### PR DESCRIPTION
Per email from TB;
I have finished making the updates to the dart_shapemodel bundle that was lien resolved by the team.  Please make an announcement on the main SBN landing page.  You can copy the 2023.10.27 release text, except stating that it has been lien resolved and locally archived.