### PR TITLE
New Horizons K6 final release 2024-06-20

### DIFF
--- a/data_sb/comet_type.shtml
+++ b/data_sb/comet_type.shtml
@@ -23,6 +23,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <!--
 ===========================================================================
 EDIT HISTORY:
++ 2024-06-20 EMW	added 2 NH-KEM SDC datasets under Particles
 + 2024-06-01 EMW	(2024-05-31) added Lucy Didymos inder Imaging
 + 2024-06-01 EMW	removed CLASSE Charon and added Pluto Albedo under Imaging, Photo, Physical
 + 2024-05-30 EMW	added CLASSE CHaron under Imaging, Photo, Physical
@@ -441,7 +442,6 @@ EDIT HISTORY:
 
 <li><a href="/holdings/nh-a-lorri-2-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Raw Data</a></li><!-- NH-A-LORRI-2-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-lorri-3-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Calibrated Data</a></li><!-- NH-A-LORRI-3-KEM2-V1.0 -->
-
 <li><a href="/holdings/pds4-nh_derived:pluto_albedo-v1.0/SUPPORT/dataset.shtml">Bolometric Hemispherical Albedo Map of Pluto from New Horizons Observations</a> <code>urn:nasa:pds:nh_derived:pluto_albedo::1.0</code></li>
 
 <li><a href="/holdings/pds4-lucy.llorri:data_didymos_raw-v1.0/SUPPORT/dataset.shtml">Lucy LOng Range Reconnaissance Imager (L'LORRI) Raw Data for the Didymos Observation Data Archive</a> <code>urn:nasa:pds:lucy.llorri:data_didymos_raw::1.0</code></li>
@@ -1000,6 +1000,8 @@ EDIT HISTORY:
 <li><a href="/holdings/vega2-c-sp2-2-rdr-halley-v1.0/dataset.shtml">Vega 2 Dust Impact Plasma Detector, Acoustic Sensor Data</a></li>
 <li><a href="/holdings/nh-a-pepssi-2-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Raw Data</a></li><!-- NH-A-PEPSSI-2-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-pepssi-3-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Calibrated Data</a></li><!-- NH-A-PEPSSI-3-KEM2-V1.0 -->
+<li><a href="/holdings/nh-a-sdc-2-kem2-v1.0/dataset.shtml">New Horizons SDC KEM2 Raw Data</a></li><!-- NH-A-SDC-2-KEM2-V1.0 -->
+<li><a href="/holdings/nh-a-sdc-3-kem2-v1.0/dataset.shtml">New Horizons SDC KEM2 Calibrated Data</a></li><!-- NH-A-SDC-3-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-swap-2-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Raw Data</a></li><!-- NH-A-SWAP-2-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-swap-3-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Calibrated Data</a></li><!-- NH-A-SWAP-3-KEM2-V1.0 -->
 </ul>
@@ -1060,7 +1062,6 @@ EDIT HISTORY:
 <li><a href="/holdings/nh-a-leisa_mvic-5-comp-v1.0/dataset.shtml">New Horizons Arrokoth Encounter Surface Composition Maps</a></li><!-- NH-A-LEISA/MVIC-5-COMP-V1.0 -->
 <li><a href="/holdings/nh-a-lorri_mvic-5-geophys-v1.0/dataset.shtml">New Horizons Arrokoth Encounter Geology and Geophysical Maps and Shape Models</a></li><!-- NH-A-LORRI/MVIC-5-GEOPHYS-V1.0 -->
 <li><a href="/holdings/ro-c-virtis-5-67p-maps-v1.0/dataset.shtml">Rosetta-Orbiter VIRTIS Derived 67P Maps</a></li><!-- RO-C-VIRTIS-5-67P-MAPS-V1.0 -->
-
 <li><a href="/holdings/pds4-nh_derived:pluto_albedo-v1.0/SUPPORT/dataset.shtml">Bolometric Hemispherical Albedo Map of Pluto from New Horizons Observations</a> <code>urn:nasa:pds:nh_derived:pluto_albedo::1.0</code></li>
 
 </ul>
@@ -1091,7 +1092,6 @@ EDIT HISTORY:
 <li><a href="/holdings/nh-x-rex-3-plutocruise-v1.0/dataset.shtml">New Horizons REX Pluto Cruise Calibrated Data</a></li><!-- NH-X-REX-3-PLUTOCRUISE-V1.0 -->
 <li><a href="/holdings/nh-p-rex-2-pluto-v2.0/dataset.shtml">New Horizons REX Pluto Encounter Raw Data v2.0</a></li><!-- NH-P-REX-2-PLUTO-V2.0 -->
 <li><a href="/holdings/nh-p-rex-3-pluto-v1.0/dataset.shtml">New Horizons REX Pluto Encounter Calibrated Data</a></li><!-- NH-P-REX-3-PLUTO-V1.0 -->
-<!-- 2017-02-07 -->
 <li><em>Please refer to <a href="/data_sb/missions/rosetta/index_RSI.shtml">Rosetta RSI</a> for a complete listing of RSI datasets.</em></li>
 <li><a href="/holdings/ro_rl-cal-consert-2-grndbench-v1.0/dataset.shtml">Rosetta-Orbiter/Lander CONSERT Laboratory Ground Benchmark Raw Data</a></li><!-- RO/RL-CAL-CONSERT-2-GRNDBENCH-V1.0 -->
 <li><a href="/holdings/ro_rl-cal-consert-2-grnd-v1.0/dataset.shtml">Rosetta-Orbiter/Lander CONSERT Flight and Qualification Ground Edited Raw Data</a></li><!-- RO/RL-CAL-CONSERT-2-GRND-V1.0 -->
@@ -1309,7 +1309,6 @@ EDIT HISTORY:
 <li><a href="/holdings/ro-c-virtis-3-ext3-mtp033-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 3 MTP033 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT3-MTP033-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-ext3-mtp034-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 3 MTP034 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT3-MTP034-V2.0 -->
 <li><a href="/holdings/ro-c-virtis-3-ext3-mtp035-v2.0/dataset.shtml">Rosetta-Orbiter VIRTIS Extension 3 MTP035 67P Calibrated Data v2.0</a></li><!-- RO-C-VIRTIS-3-EXT3-MTP035-V2.0 -->
-<!-- 2018.07.13 -->
 <li><a href="/holdings/nh-p_psa-leisa_mvic-5-comp-v1.0/dataset.shtml">New Horizons Pluto Encounter Surface Composition Maps</a></li><!-- NH-P/PSA-LEISA/MVIC-5-COMP-V1.0 -->
 <li><a href="/holdings/pds4-compil-comet:unid-emis-v1.0/SUPPORT/dataset.shtml">Catalog of Unidentified Cometary Emission Lines</a> <code>urn:nasa:pds:compil-comet:unid-emis::1.0</code></li>
 <li><a href="/holdings/pds4-gbo-mcdonald:19p_col_density-v1.0/SUPPORT/dataset.shtml">McDonald Observatory Column Density Observations of 19P/Borrelly</a> <code>urn:nasa:pds:gbo-mcdonald:19p_col_density::1.0</code></li>

--- a/data_sb/missions/nh-kem/index.shtml
+++ b/data_sb/missions/nh-kem/index.shtml
@@ -38,6 +38,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <!--
 ===========================================================================
 EDIT HISTORY:
++ 2024-06-20 EMW	added 2 SDC datasets KEM2 Cruise
 + 2024-01-30 EMW	added KEM2 Cruise datasets (8)
 + 2023-12-19 EMW	replaced NH KEM (PDS3) MVIC raw/cal v6 datasets with (PDS4) MVIC raw/cal collections; added document and calibration collections under Other
 + 2023-05-26 EMW	added NH Cosmic Optical Background Observations under Related
@@ -112,28 +113,21 @@ EDIT HISTORY:
 <ul>
 <li><a href="/holdings/nh-a-alice-2-kem1-v6.0/dataset.shtml">New Horizons ALICE KEM1 Encounter Raw Data v6.0</a></li><!-- NH-A-ALICE-2-KEM1-V6.0 -->
 <li><a href="/holdings/nh-a-alice-3-kem1-v6.0/dataset.shtml">New Horizons ALICE KEM1 Encounter Calibrated Data v6.0</a></li><!-- NH-A-ALICE-3-KEM1-V6.0 -->
-
 <li><a href="/holdings/nh-a-leisa-2-kem1-v6.0/dataset.shtml">New Horizons LEISA KEM1 Encounter Raw Data v6.0</a></li><!-- NH-A-LEISA-2-KEM1-V6.0 -->
 <li><a href="/holdings/nh-a-leisa-3-kem1-v6.0/dataset.shtml">New Horizons LEISA KEM1 Encounter Calibrated Data v6.0</a></li><!-- NH-A-LEISA-3-KEM1-V6.0 -->
-
 <li><a href="/holdings/nh-a-lorri-2-kem1-v6.0/dataset.shtml">New Horizons LORRI KEM1 Encounter Raw Data v6.0</a></li><!-- NH-A-LORRI-2-KEM1-V6.0 -->
 <li><a href="/holdings/nh-a-lorri-3-kem1-v6.0/dataset.shtml">New Horizons LORRI KEM1 Encounter Calibrated Data v6.0</a></li><!-- NH-A-LORRI-3-KEM1-V6.0 -->
-
 <li><a href="/holdings/pds4-nh_mvic:kem1_raw-v1.0/SUPPORT/dataset.shtml">New Horizons KEM1 Encounter MVIC Raw Data</a> <code>urn:nasa:pds:nh_mvic:kem1_raw::1.0</code></li>
 <li><a href="/holdings/pds4-nh_mvic:kem1_cal-v1.0/SUPPORT/dataset.shtml">New Horizons KEM1 Encounter MVIC Partially Processed Data</a> <code>urn:nasa:pds:nh_mvic:kem1_cal::1.0</code></li>
 
 <li><a href="/holdings/nh-a-pepssi-2-kem1-v6.0/dataset.shtml">New Horizons PEPSSI KEM1 Encounter Raw Data v6.0</a></li><!-- NH-A-PEPSSI-2-KEM1-V6.0 -->
 <li><a href="/holdings/nh-a-pepssi-3-kem1-v6.0/dataset.shtml">New Horizons PEPSSI KEM1 Encounter Calibrated Data v6.0</a></li><!-- NH-A-PEPSSI-3-KEM1-V6.0 -->
-
 <li><a href="/holdings/nh-a-rex-2-kem1-v5.0/dataset.shtml">New Horizons REX KEM1 Encounter Raw Data v5.0</a></li><!-- NH-A-REX-2-KEM1-V5.0 -->
 <li><a href="/holdings/nh-a-rex-3-kem1-v5.0/dataset.shtml">New Horizons REX KEM1 Encounter Calibrated Data v5.0</a></li><!-- NH-A-REX-3-KEM1-V5.0 -->
-
 <li><a href="/holdings/nh-a-sdc-2-kem1-v6.0/dataset.shtml">New Horizons SDC KEM1 Encounter Raw Data v6.0</a></li><!-- NH-A-SDC-2-KEM1-V6.0 -->
 <li><a href="/holdings/nh-a-sdc-3-kem1-v6.0/dataset.shtml">New Horizons SDC KEM1 Encounter Calibrated Data v6.0</a></li><!-- NH-A-SDC-3-KEM1-V6.0 -->
-
 <li><a href="/holdings/nh-a-swap-2-kem1-v6.0/dataset.shtml">New Horizons SWAP KEM1 Encounter Raw Data v6.0</a></li><!-- NH-A-SWAP-2-KEM1-V6.0 -->
 <li><a href="/holdings/nh-a-swap-3-kem1-v6.0/dataset.shtml">New Horizons SWAP KEM1 Encounter Calibrated Data v6.0</a></li><!-- NH-A-SWAP-3-KEM1-V6.0 -->
-
 <li><a href="/holdings/nh-a-leisa_mvic-5-comp-v1.0/dataset.shtml">New Horizons Arrokoth Encounter Surface Composition Maps</a></li><!-- NH-A-LEISA/MVIC-5-COMP-V1.0 -->
 <li><a href="/holdings/nh-a-lorri_mvic-5-geophys-v1.0/dataset.shtml">New Horizons Arrokoth Encounter Geology and Geophysical Maps and Shape Models</a></li><!-- NH-A-LORRI/MVIC-5-GEOPHYS-V1.0 -->
 </ul>
@@ -146,6 +140,8 @@ EDIT HISTORY:
 <li><a href="/holdings/nh-a-lorri-3-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Calibrated Data</a></li><!-- NH-A-LORRI-3-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-pepssi-2-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Raw Data</a></li><!-- NH-A-PEPSSI-2-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-pepssi-3-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Calibrated Data</a></li><!-- NH-A-PEPSSI-3-KEM2-V1.0 -->
+<li><a href="/holdings/nh-a-sdc-2-kem2-v1.0/dataset.shtml">New Horizons SDC KEM2 Raw Data</a></li><!-- NH-A-SDC-2-KEM2-V1.0 -->
+<li><a href="/holdings/nh-a-sdc-3-kem2-v1.0/dataset.shtml">New Horizons SDC KEM2 Calibrated Data</a></li><!-- NH-A-SDC-3-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-swap-2-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Raw Data</a></li><!-- NH-A-SWAP-2-KEM2-V1.0 -->
 <li><a href="/holdings/nh-a-swap-3-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Calibrated Data</a></li><!-- NH-A-SWAP-3-KEM2-V1.0 -->
 </ul>
@@ -160,7 +156,6 @@ EDIT HISTORY:
 <li><a href="/holdings/pds4-nh_documents:ralph-v1.0/SUPPORT/dataset.shtml">New Horizons Ralph (LEISA/MVIC) Instrument Package Documents</a> <code>urn:nasa:pds:nh_documents:ralph::1.0</code></li>
 <li><a href="/holdings/pds4-nh_mvic:calibration_files-v1.0/SUPPORT/dataset.shtml">New Horizons MVIC Calibration Files</a> <code>urn:nasa:pds:nh_mvic:calibration_files::1.0</code></li>
 </ul>
-
 
 <h3>Related Datasets</h3>
 <p>Use the <a href="https://sbnapps.psi.edu/ferret/">Small Bodies Data Ferret</a> to find other datasets for this mission/target.</p>

--- a/index.shtml
+++ b/index.shtml
@@ -58,6 +58,20 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <h2>New @ SBN</h2>
 <ul class="news">
 
+<!-- 2024.06.20 -->
+<li><span class="date">2024.06.20</span> The following New Horizons lien resolved data sets have been released:
+<br>+ <a href="/holdings/nh-a-leisa-2-kem2-v1.0/dataset.shtml">New Horizons LEISA KEM2 Raw Data</a><!-- NH-A-LEISA-2-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-leisa-3-kem2-v1.0/dataset.shtml">New Horizons LEISA KEM2 Calibrated Data</a><!-- NH-A-LEISA-3-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-lorri-2-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Raw Data</a><!-- NH-A-LORRI-2-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-lorri-3-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Calibrated Data</a><!-- NH-A-LORRI-3-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-pepssi-2-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Raw Data</a><!-- NH-A-PEPSSI-2-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-pepssi-3-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Calibrated Data</a><!-- NH-A-PEPSSI-3-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-sdc-2-kem2-v1.0/dataset.shtml">New Horizons SDC KEM2 Raw Data</a><!-- NH-A-SDC-2-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-sdc-3-kem2-v1.0/dataset.shtml">New Horizons SDC KEM2 Calibrated Data</a><!-- NH-A-SDC-3-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-swap-2-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Raw Data</a><!-- NH-A-SWAP-2-KEM2-V1.0 -->
+<br>+ <a href="/holdings/nh-a-swap-3-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Calibrated Data</a><!-- NH-A-SWAP-3-KEM2-V1.0 -->
+</li>
+
 <!-- 2024.05.31 -->
 <li><span class="date">2024.05.31</span>
 <br>+ <a href="/holdings/pds4-lucy.llorri-v1.0/SUPPORT/dataset.shtml">Lucy Mission L'LORRI Instrument Bundle</a> <code>urn:nasa:pds:lucy.llorri::1.0</code>
@@ -69,14 +83,11 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 </ul>
 </li>
 
-
-
 <!-- 2024.05.30 -->
 <li><span class="date">2024.05.30</span> The following R&amp;A datasets have been posted:
 <br>+ <a href="/holdings/pds4-nh_derived:pluto_albedo-v1.0/SUPPORT/dataset.shtml">Bolometric Hemispherical Albedo Map of Pluto from New Horizons Observations</a> <code>urn:nasa:pds:nh_derived:pluto_albedo::1.0</code>
 <br>+ <a href="/holdings/pds4-gbl-classe:charon_exosphere-v1.0/SUPPORT/dataset.shtml">Center for Laboratory Astrophysics and Space Science Experiments (CLASSE) Charon Exospheric Simulation Data</a> <code>urn:nasa:pds:gbl-classe:charon_exosphere::1.0</code>
 </li>
-
 
 <!-- 2024.05.15 -->
 <li><span class="date">2024.05.15</span>
@@ -88,103 +99,6 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <li><a href="/holdings/pds4-dart_shapemodel:document-v1.0/SUPPORT/dataset.shtml">Documentation Collection for the DART Shapemodel Archive Bundle</a> <code>urn:nasa:pds:dart_shapemodel:document::1.0</code></li>
 </ul>
 </li>
-
-
-<!-- 2024.01.30 -->
-<li><span class="date">2024.01.30</span> The following New Horizons KEM2 data sets have been released:
-<br>+ <a href="/holdings/nh-a-leisa-2-kem2-v1.0/dataset.shtml">New Horizons LEISA KEM2 Raw Data</a><!-- NH-A-LEISA-2-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-leisa-3-kem2-v1.0/dataset.shtml">New Horizons LEISA KEM2 Calibrated Data</a><!-- NH-A-LEISA-3-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-lorri-2-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Raw Data</a><!-- NH-A-LORRI-2-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-lorri-3-kem2-v1.0/dataset.shtml">New Horizons LORRI KEM2 Calibrated Data</a><!-- NH-A-LORRI-3-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-pepssi-2-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Raw Data</a><!-- NH-A-PEPSSI-2-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-pepssi-3-kem2-v1.0/dataset.shtml">New Horizons PEPSSI KEM2 Calibrated Data</a><!-- NH-A-PEPSSI-3-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-swap-2-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Raw Data</a><!-- NH-A-SWAP-2-KEM2-V1.0 -->
-<br>+ <a href="/holdings/nh-a-swap-3-kem2-v1.0/dataset.shtml">New Horizons SWAP KEM2 Calibrated Data</a><!-- NH-A-SWAP-3-KEM2-V1.0 -->
-</li>
-
-
-<!-- 2023.12.19 -->
-<li><span class="date">2023.12.19</span> The following data sets have been migrated from PDS3 to PDS4 archive standards. The data has remained unchanged.
-<br>+ <a href="/holdings/pds4-nh_documents:mission-v1.0/SUPPORT/dataset.shtml">New Horizons Mission Documents</a> <code>urn:nasa:pds:nh_documents:mission::1.0</code>
-<br>+ <a href="/holdings/pds4-nh_documents:ralph-v1.0/SUPPORT/dataset.shtml">New Horizons Ralph (LEISA/MVIC) Instrument Package Documents</a> <code>urn:nasa:pds:nh_documents:ralph::1.0</code>
-<br>+ <a href="/holdings/pds4-nh_mvic:calibration_files-v1.0/SUPPORT/dataset.shtml">New Horizons MVIC Calibration Files</a> <code>urn:nasa:pds:nh_mvic:calibration_files::1.0</code>
-<br>+ <a href="/holdings/pds4-nh_mvic:kem1_raw-v1.0/SUPPORT/dataset.shtml">New Horizons KEM1 Encounter MVIC Raw Data</a> <code>urn:nasa:pds:nh_mvic:kem1_raw::1.0</code>
-<br>+ <a href="/holdings/pds4-nh_mvic:kem1_cal-v1.0/SUPPORT/dataset.shtml">New Horizons KEM1 Encounter MVIC Partially Processed Data</a> <code>urn:nasa:pds:nh_mvic:kem1_cal::1.0</code>
-</li>
-
-<!-- 2023.12.15 -->
-<li><span class="date">2023.12.15</span>
-<br>+ <a href="/holdings/pds4-dart:data_dracoddp-v1.0/SUPPORT/dataset.shtml">DART Calibrated Images with Geometric Backplanes for the Didymos Reconnaissance and Asteroid Camera for OpNav (DRACO) instrument</a> <code>urn:nasa:pds:dart:data_dracoddp::1.0</code>
-<br>+ <a href="/holdings/pds4-liciacube:leia_calibrated-v1.0/SUPPORT/dataset.shtml">LICIACube Explorer Imaging for Asteroid (LEIA) Calibrated Data Collection</a> <code>urn:nasa:pds:liciacube:leia_calibrated::1.0</code>
-<br>+ <a href="/holdings/pds4-liciacube:luke_calibrated-v1.0/SUPPORT/dataset.shtml">LICIACube Unit Key Explorer (LUKE) Calibrated Data Collection</a> <code>urn:nasa:pds:liciacube:luke_calibrated::1.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:data_lcoimacsddp-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory IMACS Magellan Baade 6.5m Telescope Photometry Derived Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcoimacsddp::1.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:data_lcoswopeddp-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory Swope 1m Telescope Photometry Derived Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcoswopeddp::1.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:data_lcogtraw-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory Sinistro Imager Raw Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcogtraw::1.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:data_ldtraw-v2.0/SUPPORT/dataset.shtml">DART Lowell Discovery Telescope (LDT) Raw Data Collection v2.0</a> <code>urn:nasa:pds:dart_teleobs:data_ldtraw::2.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:data_ldtcal-v2.0/SUPPORT/dataset.shtml">DART Lowell Discovery Telescope (LDT) Calibrated Data Collection v2.0</a> <code>urn:nasa:pds:dart_teleobs:data_ldtcal::2.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:data_ldtddp-v2.0/SUPPORT/dataset.shtml">DART Lowell Discovery Telescope (LDT) Derived Data Product Collection v2.0</a> <code>urn:nasa:pds:dart_teleobs:data_ldtddp::2.0</code>
-<br>+ <a href="/holdings/pds4-dart_teleobs:document_ldt-v2.0/SUPPORT/dataset.shtml">DART Lowell Document Collection v2.0</a> <code>urn:nasa:pds:dart_teleobs:document_ldt::2.0</code>
-</li>
-
-<!-- 2023.10.27 -->
-<li><span class="date">2023.10.27</span>
-<br>+ <a href="/holdings/pds4-dart_shapemodel-v1.0/SUPPORT/dataset.shtml">DART Shapemodel Archive Bundle</a> <code>urn:nasa:pds:dart_shapemodel::1.0</code> has been made publicly available and includes the following collections:
-<ul>
-<li><a href="/holdings/pds4-dart_shapemodel:data_derived_didymos_model_v003-v1.0/SUPPORT/dataset.shtml">Derived data products for DART shapemodel: didymos_model_v003</a> <code>urn:nasa:pds:dart_shapemodel:data_derived_didymos_model_v003::1.0</code></li>
-<li><a href="/holdings/pds4-dart_shapemodel:data_derived_dimorphos_model_v003-v1.0/SUPPORT/dataset.shtml">Derived data products for DART shapemodel: dimorphos_model_v003</a> <code>urn:nasa:pds:dart_shapemodel:data_derived_dimorphos_model_v003::1.0</code></li>
-<li><a href="/holdings/pds4-dart_shapemodel:data_derived_dimorphos_model_v004-v1.0/SUPPORT/dataset.shtml">Derived data products for DART shapemodel: dimorphos_model_v004</a> <code>urn:nasa:pds:dart_shapemodel:data_derived_dimorphos_model_v004::1.0</code></li>
-<li><a href="/holdings/pds4-dart_shapemodel:document-v1.0/SUPPORT/dataset.shtml">Documentation Collection for the DART Shapemodel Archive Bundle</a> <code>urn:nasa:pds:dart_shapemodel:document::1.0</code></li>
-</ul>
-</li>
-
-
-<!-- 2023.10.25 -->
-<li><span class="date">2023.10.25</span>
-<br>+ <a href="/holdings/pds4-dart_teleobs-v2.0/SUPPORT/dataset.shtml">DART Telescopic Observation Archive v2.0</a> <code>urn:nasa:pds:dart_teleobs::2.0</code> (in lien resolution) which in part includes the following newly released collections:
-<ul>
-<li><a href="/holdings/pds4-dart_teleobs:document_lco-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory Telescopic Observations Documentation Collection</a> <code>urn:nasa:pds:dart_teleobs:document_lco::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcoimacsraw-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory IMACS Magellan Baade 6.5m Telescope Raw Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcoimacsraw::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcoimacscal-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory IMACS Magellan Baade 6.5m Telescope Calibrated Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcoimacscal::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcoswoperaw-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory Swope 1m Telescope Raw Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcoswoperaw::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcoswopecal-v1.0/SUPPORT/dataset.shtml">DART Las Campanas Observatory Swope 1m Telescope Calibrated Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcoswopecal::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:document_lcogt-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory 1.0m Telescope Documentation Collection</a> <code>urn:nasa:pds:dart_teleobs:document_lcogt::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcogt_fliraw-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory Network (LCOGT) Finger Lakes Instrumentation (FLI) Raw Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcogt_fliraw::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcogt_flical-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory Network (LCOGT) Finger Lakes Instrumentation (FLI) Calibrated Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcogt_flical::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcogt_fliddp-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory Network (LCOGT) Finger Lakes Instrumentation (FLI) Derived Data Product Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcogt_fliddp::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcogtcal-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory Network (LCOGT) Sinistro Imager Calibrated Data Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcogtcal::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_lcogtddp-v1.0/SUPPORT/dataset.shtml">DART Las Cumbres Observatory Network (LCOGT) Sinistro Imager Derived Data Product Collection</a> <code>urn:nasa:pds:dart_teleobs:data_lcogtddp::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:document_mro-v1.0/SUPPORT/dataset.shtml">DART Magdalena Ridge Observatory 2.4m Telescope Documentation Collection</a> <code>urn:nasa:pds:dart_teleobs:document_mro::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_mroraw-v1.0/SUPPORT/dataset.shtml">DART Magdalena Ridge Observatory 2.4m Telescope Raw Data Product Collection</a> <code>urn:nasa:pds:dart_teleobs:data_mroraw::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_mrocal-v1.0/SUPPORT/dataset.shtml">DART Magdalena Ridge Observatory 2.4m Telescope Calibrated Data Product Collection</a> <code>urn:nasa:pds:dart_teleobs:data_mrocal::1.0</code></li>
-<li><a href="/holdings/pds4-dart_teleobs:data_mroddp-v1.0/SUPPORT/dataset.shtml">DART Magdalena Ridge Observatory 2.4m Telescope Derived Data Product Collection</a> <code>urn:nasa:pds:dart_teleobs:data_mroddp::1.0</code></li>
-</ul>
-</li>
-
-
-<!-- 2023.10.20 -->
-<li><span class="date">2023.10.20</span>
-<br>+ <a href="/holdings/pds4-dart-v3.0/SUPPORT/dataset.shtml">DART Spacecraft Archive Bundle v3.0</a> <code>urn:nasa:pds:dart::3.0</code> (in lien resolution) which in part includes the following newly released collections:
-<ul>
-<li><a href="/holdings/pds4-dart:data_dracoraw-v3.0/SUPPORT/dataset.shtml">DART Raw Images for the Didymos Reconnaissance and Asteroid Camera for OpNav (DRACO) instrument v3.0</a> <code>urn:nasa:pds:dart:data_dracoraw::3.0</code></li>
-<li><a href="/holdings/pds4-dart:data_dracocal-v3.0/SUPPORT/dataset.shtml">DART Calibrated Images for the Didymos Reconnaissance and Asteroid Camera for OpNav (DRACO) instrument v3.0</a> <code>urn:nasa:pds:dart:data_dracocal::3.0</code></li>
-<li><a href="/holdings/pds4-dart:document_draco-v3.0/SUPPORT/dataset.shtml">DART Documentation for the Didymos Reconnaissance and Asteroid Camera for OpNav (DRACO) instrument v3.0</a> <code>urn:nasa:pds:dart:document_draco::3.0</code></li>
-</ul>
-<br>+ <a href="/holdings/pds4-liciacube-v1.0/SUPPORT/dataset.shtml">Light Italian Cubesat for Imaging of Asteroids (LICIACube) Spacecraft Bundle</a> <code>urn:nasa:pds:liciacube::1.0</code> (in lien resolution) which in part includes the following newly released collections:
-<ul>
-<li><a href="/holdings/pds4-liciacube:document-v1.0/SUPPORT/dataset.shtml">Light Italian Cubesat for Imaging of Asteroids (LICIACube) Document Collection</a> <code>urn:nasa:pds:liciacube:document::1.0</code></li>
-<li><a href="/holdings/pds4-liciacube:leia_raw-v1.0/SUPPORT/dataset.shtml">Liciacube Explorer Imaging for Asteroid (LEIA) Light Italian Cubesat for Imaging of Asteroids (LICIACube) Raw Data Collection</a> <code>urn:nasa:pds:liciacube:leia_raw::1.0</code></li>
-<li><a href="/holdings/pds4-liciacube:luke_raw-v1.0/SUPPORT/dataset.shtml">Liciacube Unit Key Explorer (LUKE) Light Italian Cubesat for Imaging of Asteroids (LICIACube) Raw Data Collection</a> <code>urn:nasa:pds:liciacube:luke_raw::1.0</code></li>
-<li><a href="/holdings/pds4-liciacube:data_tnf-v1.0/SUPPORT/dataset.shtml">LICIACube Radio Science Tracking and Navigation Files (TRK-2-34) Data Collection</a> <code>urn:nasa:pds:liciacube:data_tnf::1.0</code></li>
-</ul>
-</li>
-
-
-<!-- 2023.06.01 -->
-<li><span class="date">2023.06.01</span>
-<br>+ <a href="/holdings/pds4-ro_derived:dfms_ts_abundance-v1.0/SUPPORT/dataset.shtml">Rosetta ROSINA DFMS Time Series Abundances</a> <code>urn:nasa:pds:ro_derived:dfms_ts_abundance::1.0</code>
-</li>
-
-
 
 </ul>
 


### PR DESCRIPTION
releasing the lien resolved copy of the New Horizons K6 data sets on Thursday June 20th.  The only "new" data sets are the two SDC data sets.