### PR TITLE
update links.shtml

### DIFF
--- a/about/links.shtml
+++ b/about/links.shtml
@@ -64,7 +64,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <li><a href="https://cometografia.es/" onclick="this.target='_blank'">Cometografia</a></li>
 <li><a href="http://aerith.net/" onclick="this.target='_blank'">Seiichi Yoshida's Comet Observing</a></li>
 <li><a href="http://fg-kometen.vdsastro.de/fgk_hpe.htm" onclick="this.target='_blank'">The German comet group</a></li>
-<li><a href="http://www.ast.cam.ac.uk/~jds/" onclick="this.target='_blank'">British Astronomical Association</a> Comet Section</li>
+<li><a href="https://britastro.org/sections/comet" onclick="this.target='_blank'">British Astronomical Association</a> Comet Section</li>
 </ul>
 
 <h2>Man-made Satellites</h2>
@@ -78,7 +78,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <ul>
 <!-- <li><a href="http://impact.arc.nasa.gov/" onclick="this.target='_blank'">Asteroid and Comet Impact Hazards</a></li> -->
 <li><a href="https://cneos.jpl.nasa.gov/" onclick="this.target='_blank'">Center for Near Earth Object Studies</a></li><!-- <li><a href="http://spaceguard.iaps.inaf.it/" onclick="this.target='_blank'">Spaceguard Foundation</a></li> -->
-<li><a href="https://spacewatch.lpl.arizona.edu/" onclick="this.target='_blank'">The Spacewatch Project</a></li>
+<!-- <li><a href="https://spacewatch.lpl.arizona.edu/" onclick="this.target='_blank'">The Spacewatch Project</a></li> --><!-- 12 Feb 2025: link hidden due to directive -->
 </ul>
 
 <h2>Meteors, Meteorites</h2>
@@ -139,7 +139,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <ul>
 <li><a href="http://adswww.harvard.edu/" onclick="this.target='_blank'">The SAO/NASA Astrophysics Data System</a></li>
 <li><a href="https://arxiv.org/list/astro-ph.EP/recent/" onclick="this.target='_blank'">arXiv Astrophysics: Earth and Planetary Astronomy</a>, recent papers</li>
-<li><a href="http://digitalcommons.library.arizona.edu/holdings/journal?r=uadc://azu_maps/" onclick="this.target='_blank'">Meteoritics and Planetary Science</a></li>
+<li><a href="https://onlinelibrary.wiley.com/journal/19455100" onclick="this.target='_blank'">Meteoritics and Planetary Science</a></li>
 <li><a href="http://www.icq.eps.harvard.edu/CCDmags.html" onclick="this.target='_blank'">CCD Photometry of Faint Comets</li>
 </ul>
 


### PR DESCRIPTION
per email from Gerbs, removed link to Spacewatch because the site host Arizona has icontroversial statement at the bottom of all their pages. Another link was simply bad and I found updated version. Third link also originally to AZ was also technically bad (but not 404) and I found new site (not at AZ).