### PR TITLE
fixed links

### DIFF
--- a/data_sb/comet_type.shtml
+++ b/data_sb/comet_type.shtml
@@ -23,6 +23,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <!--
 ===========================================================================
 EDIT HISTORY:
++ 2025-05-16 EMW	fixed SWAN Derived link to v3.0
 + 2025-05-16 EMW	Alice Pluto Encounter migrated datasets
 + 2025-05-09 EMW	LEISSA, MVIC, SDC Pluto Encounter migrated datasets
 + 2025-02-14 EMW	PEPSSI (PDS3) v6 to (PDS4) v1 PEPSSI Data Archive
@@ -1071,7 +1072,7 @@ EDIT HISTORY:
 <li><a href="/holdings/pds4-compil-comet:nuc_properties-v1.0/SUPPORT/dataset.shtml">Properties of Comet Nuclei</a> <code>urn:nasa:pds:compil-comet:nuc_properties::1.0</code></li>
 <li><a href="/holdings/ear-c-phot-5-rdr-lowell-comet-db-pr-v1.0/dataset.shtml">Lowell Observatory Cometary Database - Production Rates</a></li>
 <li><a href="/holdings/pds4-compil-comet:nuc_rotation-v1.0/SUPPORT/dataset.shtml">Rotation of Comet Nuclei: Table 1</a> <code>urn:nasa:pds:compil-comet:nuc_rotation::1.0</code></li>
-<li><a href="/holdings/pds4-soho:swan_derived-v1.0/SUPPORT/dataset.shtml">SOHO SWAN Derived Cometary Water Production Rates Collection v3.0</a> <code>urn:nasa:pds:soho:swan_derived::v3.0</code></li>
+<li><a href="/holdings/pds4-soho:swan_derived-v3.0/SUPPORT/dataset.shtml">SOHO SWAN Derived Cometary Water Production Rates Collection v3.0</a> <code>urn:nasa:pds:soho:swan_derived::v3.0</code></li>
 <li><a href="/holdings/rl-cal-mupus-2-phc-v1.0/dataset.shtml">Rosetta-Lander MUPUS Post Hibernation Commissioning Raw Data</a></li><!-- RL-CAL-MUPUS-2-PHC-V1.0 -->
 <li><a href="/holdings/rl-cal-mupus-3-phc-v1.0/dataset.shtml">Rosetta-Lander MUPUS Post Hibernation Commissioning Calibrated Data</a></li><!-- RL-CAL-MUPUS-3-PHC-V1.0 -->
 <li><a href="/holdings/rl-c-mupus-2-sdl-v1.0/dataset.shtml">Rosetta-Lander MUPUS Separation Descent Landing 67P Raw Data</a></li><!-- RL-C-MUPUS-2-SDL-V1.0 -->

--- a/data_sb/missions/soho/index.shtml
+++ b/data_sb/missions/soho/index.shtml
@@ -35,6 +35,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <!--
 ===========================================================================
 EDIT HISTORY:
++ 2025-05-16 EMW	fixed SOHO document link to v1.1, SWAN Derived link to v3.0
 + 2020-04-28 EMW	updated doc collection to v1.1, SWAN to v2.0
 + 2017-03-10 EMW	added links to instruments, added SWAN instrument, added 2 PDS4 datasets
 + 2014-11-20 EMW	updated link to Ferret
@@ -67,8 +68,8 @@ EDIT HISTORY:
 <li><a href="/holdings/soho-c-lasco-4-cometimages-v1.0/dataset.shtml">SOHO Comet Images</a></li>
 <li><a href="/holdings/soho-c-lasco-5-kreutzphotom-v1.0/dataset.shtml">SOHO Photometry of Kreutz Family Comets</a></li>
 
-<li><a href="/holdings/pds4-soho:document-v1.0/SUPPORT/dataset.shtml">SOHO Documentation Collection v1.1</a> <code>urn:nasa:pds:soho:document::v1.1</code></li>
-<li><a href="/holdings/pds4-soho:swan_derived-v1.0/SUPPORT/dataset.shtml">SOHO SWAN Derived Cometary Water Production Rates Collection v3.0</a> <code>urn:nasa:pds:soho:swan_derived::v3.0</code></li>
+<li><a href="/holdings/pds4-soho:document-v1.1/SUPPORT/dataset.shtml">SOHO Documentation Collection v1.1</a> <code>urn:nasa:pds:soho:document::v1.1</code></li>
+<li><a href="/holdings/pds4-soho:swan_derived-v3.0/SUPPORT/dataset.shtml">SOHO SWAN Derived Cometary Water Production Rates Collection v3.0</a> <code>urn:nasa:pds:soho:swan_derived::v3.0</code></li>
 </ul>
 
 <h3>Related Datasets</h3>

--- a/data_sb/target_comets.shtml
+++ b/data_sb/target_comets.shtml
@@ -109,6 +109,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <!--
 ===========================================================================
 EDIT HISTORY:
++ 2025-05-16 EMW	fixed SWAN Derived link to v3.0
 + 2023-06-01 EMW	ROSINA DFMS Time Series Abundances under  67P
 + 2023-02-15 EMW	because this is an EU mission, changed instances of maneuver to manoeuvre for consistency in the Rosetta datasets
 + 2023-02-09 EMW	8 RPCMIP derived data (PRL-EXT3), 8 RPCMIP/RPCLAP Cross-Calibrated Derived Data (PRL-EXT3) under 67P
@@ -1652,7 +1653,7 @@ EDIT HISTORY:
 <li><a href="/holdings/pds4-compil-comet:nuc_rotation-v1.0/SUPPORT/dataset.shtml">Rotation of Comet Nuclei: Table 1</a> <code>urn:nasa:pds:compil-comet:nuc_rotation::1.0</code></li>
 <li><a href="https://sbn.psi.edu/pds/resource/msxsb.html">MSX Small Bodies Images</a> (infrared images of eight comets from the MSX mission)</li>
 <li><a href="https://sbn.psi.edu/pds/resource/tnocencol.html">TNO and Centaur Colors</a> (broadband colors of four comets with Centaur-like orbits)</li>
-<li><a href="/holdings/pds4-soho:swan_derived-v1.0/SUPPORT/dataset.shtml">SOHO SWAN Derived Cometary Water Production Rates Collection v3.0</a> <code>urn:nasa:pds:soho:swan_derived::v3.0</code></li>
+<li><a href="/holdings/pds4-soho:swan_derived-v3.0/SUPPORT/dataset.shtml">SOHO SWAN Derived Cometary Water Production Rates Collection v3.0</a> <code>urn:nasa:pds:soho:swan_derived::v3.0</code></li>
 
 <li><a href="/holdings/pds4-compil-comet:unid-emis-v1.0/SUPPORT/dataset.shtml">Catalog of Unidentified Cometary Emission Lines</a> <code>urn:nasa:pds:compil-comet:unid-emis::1.0</code></li>
 <li><a href="/holdings/pds4-spitzer:spitzer-spec-comet-v1.0/SUPPORT/dataset.shtml">Spitzer Space Telescope Spectroscopy of Comets</a> <code>urn:nasa:pds:spitzer:spitzer-spec-comet::1.0</code></li>


### PR DESCRIPTION
Per email from TB, fixed links that had incorrect version number even though rest of line (link name, lidvid) were correct.