### PR TITLE
remove links to R&A page

### DIFF
--- a/css-n-includes/incl_left-side.inc
+++ b/css-n-includes/incl_left-side.inc
@@ -19,7 +19,7 @@
 <li>Data-related Resources
 	<ul>
 	<li>+ <a href="/data_sb/resources/coordinate_systems.shtml">Coordinate Systems @ PDS-SBN</a></li>
-	<li>+ <a href="/data_sb/resources/release_sched.shtml">Data Release Schedule</a></li>
+	<!-- <li>+ <a href="/data_sb/resources/release_sched.shtml">Data Release Schedule</a></li> --><!-- 2026-04-29 per SBN discussion, remove links to R&A schedule -->
 	<li>+ <a href="/data_sb/resources/designation_formats.shtml">Small Body Designation Formats</a></li>
 	<li>+ <a href="/data_sb/resources/periodic_comets.shtml">Periodic Comet Names &amp; Designations</a></li>
 	

--- a/css-n-includes/incl_top.inc
+++ b/css-n-includes/incl_top.inc
@@ -99,7 +99,7 @@ a:active {} /* requires a blank style for :active to stop it being buggy */
 		<li><a href="https://archives.esac.esa.int/psa/" onclick="this.target='_blank'" class="external"><span class="item">ESA Planetary<br />Sci Archive</span></a></li>
 		</ul></li><!-- end fly 'SB Data Elsewhere' -->
 	<li><a href="/data_sb/resources/coordinate_systems.shtml"><span class="item">Coordinate Systems @ PDS-SBN</span></a></li>
-	<li><a href="/data_sb/resources/release_sched.shtml"><span class="item">Data Release Schedule</span></a></li>
+	<!-- <li><a href="/data_sb/resources/release_sched.shtml"><span class="item">Data Release Schedule</span></a></li> --><!-- 2026-04-29 per SBN discussion, remove links to R&A schedule -->
 	<li><a href="/data_sb/resources/designation_formats.shtml"><span class="item">Small Body Designation Formats</span></a></li>
 	<li><a href="/data_sb/resources/periodic_comets.shtml"><span class="item">Periodic Comet Names &amp; Designations</span></a></li>
 </ul>

--- a/data_sb/resources/release_sched.shtml
+++ b/data_sb/resources/release_sched.shtml
@@ -22,6 +22,19 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 <!-- ************************************************** You may begin editing! ************************************************** -->
 <h1>Data Release Schedule</h1>
 
+<!-- BEGIN  banner -->
+
+<table class="important">
+<tr>
+<td><h1>Deprecated Page</h1>
+<p>This page is no longer maintained. We haven't deleted it... yet! But it will no longer be updated.</p>
+<!-- 2026-04-29 per SBN discussion, remove links to R&A schedule -->
+</td>
+</tr>
+</table>
+
+<!-- END banner -->
+
 <p>The Planetary Data System now maintains a unified <a href="https://pds.nasa.gov/datasearch/subscription-service/data-release-calendar.shtml">PDS Data Release Calendar</a> for <em>missions</em>. That calendar may track non-mission releases.</p>
 
 <p>This schedule is posted to show what non-mission data we expect to provide to the public in the <em>near future</em>. The unlinked date in the last column is a rough estimation of the data release (data however are expected to be <em>delivered</em> to SBN several months earlier so that they can be reviewed, lien-resolved, etc before release). After the release, we will link to the data from this page <strong><em>for up to 6 months after release</em></strong>. You can always find links to <em>all of the released data</em> from the &quot;Data Archives&quot; menu above.</p>

--- a/index.shtml
+++ b/index.shtml
@@ -42,7 +42,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 </ul>
 
 <h2>Data Release Schedule</h2>
-<p>The <a href="https://pds.nasa.gov/datasearch/subscription-service/data-release-calendar.shtml">PDS Data Release Calendar</a> has the proposed dates of when mission data provided to the SBN for archiving will be publicly available. Additionally, SBN maintains a ground-based and R&amp;A <a href="/data_sb/resources/release_sched.shtml">data release schedule</a>.</p>
+<p>The <a href="https://pds.nasa.gov/datasearch/subscription-service/data-release-calendar.shtml">PDS Data Release Calendar</a> has the proposed dates of when mission data provided to the SBN for archiving will be publicly available. <!-- Additionally, SBN maintains a ground-based and R&amp;A <a href="/data_sb/resources/release_sched.shtml">data release schedule</a>. --><!-- 2026-04-29 per SBN discussion, remove links to R&A schedule --></p>
 <h2>New @ SBN</h2>
 <ul class="news">
 

--- a/sitemap.shtml
+++ b/sitemap.shtml
@@ -43,7 +43,7 @@ ALL of the head, style links, header and menu code is in the include. Edit that 
 		<li><a href="https://archives.esac.esa.int/psa/" onclick="this.target='_blank'" class="external">ESA Planetary Sci Archive</a></li>
 		</ul></li><!-- end 'SB Data Elsewhere' -->
 	<li><a href="/data_sb/resources/coordinate_systems.shtml">Coordinate Systems @ PDS-SBN</a></li>
-	<li><a href="/data_sb/resources/release_sched.shtml">Data Release Schedule</a></li>
+	<!-- <li><a href="/data_sb/resources/release_sched.shtml">Data Release Schedule</a></li> --><!-- 2026-04-29 per SBN discussion, remove links to R&A schedule -->
 	<li><a href="/data_sb/resources/designation_formats.shtml">Small Body Designation Formats</a></li>
 	<li><a href="/data_sb/resources/periodic_comets.shtml">Periodic Comet Names &amp; Designations</a></li>
 </ul>


### PR DESCRIPTION
per SBN group discussion, decided to longer maintain the R&A release schedule page. The page is not deleted but the links to it have been 'removed' and a banner placed on the page noting that it has been deprecated.